### PR TITLE
Make smoke tests check that wrong branch of Conditional is not evaluated if the correct one is empty/None

### DIFF
--- a/run_smoke_tests.py
+++ b/run_smoke_tests.py
@@ -65,6 +65,16 @@ def test_conditional():
     assert cond.evaluate(scope) is true
     cond = model.Conditional(false, None, [f])
     assert cond.evaluate(scope) is true
+    # If one of the following assertions fail, it means that Conditional has
+    # evaluated wrong branch.
+    cond = model.Conditional(false, [true], None)
+    assert cond.evaluate(scope) is not true
+    cond = model.Conditional(false, [true], [])
+    assert cond.evaluate(scope) is not true
+    cond = model.Conditional(true, None, [false])
+    assert cond.evaluate(scope) is not false
+    cond = model.Conditional(true, [], [false])
+    assert cond.evaluate(scope) is not false
 
 def test_function_call():
     arg_name = "arg"


### PR DESCRIPTION
<a href="https://github.com/murfel/paradigms2016/blob/052885eec6243f8f5e22604e602abb7f6ca13a02/para-task-04/model.py#L102-L108">Example of wrong code</a>.

Extended version of #5, implemented inside smoke tests, so it can check that `None` is handled as well.
